### PR TITLE
Use rollup external config for css import filters

### DIFF
--- a/packages/vite/types/shims.d.ts
+++ b/packages/vite/types/shims.d.ts
@@ -61,6 +61,7 @@ declare module 'postcss-load-config' {
 declare module 'postcss-import' {
   import { Plugin } from 'postcss'
   const plugin: (options: {
+    filter: (id: string) => boolean,
     resolve: (
       id: string,
       basedir: string,


### PR DESCRIPTION
So that we can build in lib mode retaining css @import external.
Doesn't fully work though because postcss-import filter doesn't provide importer when filtering imports.