### PR TITLE
fix(alias): custom resolver on rollup plugin

### DIFF
--- a/packages/vite/src/browser/config.ts
+++ b/packages/vite/src/browser/config.ts
@@ -107,6 +107,13 @@ export async function resolveConfig(
   const createResolver: ResolvedConfig['createResolver'] = (options) => {
     let aliasContainer: PluginContainer | undefined
     let resolverContainer: PluginContainer | undefined
+    const createAliasPlugin = () =>
+      aliasPlugin({
+        entries: resolved.resolve.alias,
+        customResolver: function (this, updatedId, importer) {
+          return this.resolve(updatedId, importer, { skipSelf: true })
+        }
+      })
     return async (id, importer, aliasOnly, ssr) => {
       let container: PluginContainer
       if (aliasOnly) {
@@ -114,7 +121,7 @@ export async function resolveConfig(
           aliasContainer ||
           (aliasContainer = await createPluginContainer({
             ...resolved,
-            plugins: [aliasPlugin({ entries: resolved.resolve.alias })]
+            plugins: [createAliasPlugin()]
           }))
       } else {
         container =
@@ -122,7 +129,7 @@ export async function resolveConfig(
           (resolverContainer = await createPluginContainer({
             ...resolved,
             plugins: [
-              aliasPlugin({ entries: resolved.resolve.alias }),
+              createAliasPlugin(),
               resolvePlugin({
                 ...resolved.resolve,
                 root: resolvedRoot,

--- a/packages/vite/src/browser/plugins/index.ts
+++ b/packages/vite/src/browser/plugins/index.ts
@@ -24,7 +24,12 @@ export async function resolvePlugins(
 
   return [
     isBuild ? null : preAliasPlugin(),
-    aliasPlugin({ entries: config.resolve.alias }),
+    aliasPlugin({
+      entries: config.resolve.alias,
+      customResolver: function (this, updatedId, importer) {
+        return this.resolve(updatedId, importer, { skipSelf: true })
+      }
+    }),
     ...prePlugins,
     // config.build.polyfillModulePreload
     //   ? modulePreloadPolyfillPlugin(config)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -388,6 +388,13 @@ export async function resolveConfig(
   const createResolver: ResolvedConfig['createResolver'] = (options) => {
     let aliasContainer: PluginContainer | undefined
     let resolverContainer: PluginContainer | undefined
+    const createAliasPlugin = () =>
+      aliasPlugin({
+        entries: resolved.resolve.alias,
+        customResolver: function (this, updatedId, importer) {
+          return this.resolve(updatedId, importer, { skipSelf: true })
+        }
+      })
     return async (id, importer, aliasOnly, ssr) => {
       let container: PluginContainer
       if (aliasOnly) {
@@ -395,7 +402,7 @@ export async function resolveConfig(
           aliasContainer ||
           (aliasContainer = await createPluginContainer({
             ...resolved,
-            plugins: [aliasPlugin({ entries: resolved.resolve.alias })]
+            plugins: [createAliasPlugin()]
           }))
       } else {
         container =
@@ -403,7 +410,7 @@ export async function resolveConfig(
           (resolverContainer = await createPluginContainer({
             ...resolved,
             plugins: [
-              aliasPlugin({ entries: resolved.resolve.alias }),
+              createAliasPlugin(),
               resolvePlugin({
                 ...resolved.resolve,
                 root: resolvedRoot,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -30,7 +30,12 @@ export async function resolvePlugins(
 
   return [
     isBuild ? null : preAliasPlugin(),
-    aliasPlugin({ entries: config.resolve.alias }),
+    aliasPlugin({
+      entries: config.resolve.alias,
+      customResolver: function (this, updatedId, importer) {
+        return this.resolve(updatedId, importer, { skipSelf: true })
+      }
+    }),
     ...prePlugins,
     config.build.polyfillModulePreload
       ? modulePreloadPolyfillPlugin(config)


### PR DESCRIPTION
This avoids the rollup alias plugin resolving every mapped
id, therefore if the mapped id cannot be resolved a proper
resolution error is raised