### PR TITLE
fix(browser): no longer use existsSync for id resolution

### DIFF
--- a/packages/vite/src/browser/plugins/resolve.ts
+++ b/packages/vite/src/browser/plugins/resolve.ts
@@ -9,7 +9,8 @@ import {
   isDataUrl,
   isTsRequest,
   isPossibleTsOutput,
-  getTsSrcPath
+  getTsSrcPath,
+  isFileReadable
 } from '../../node/utils'
 import type { ViteDevServer, InternalResolveOptions } from '../../node'
 import type { PartialResolvedId } from 'rollup'
@@ -231,11 +232,13 @@ function tryResolveFile(
   skipPackageJson?: boolean
 ): string | undefined {
   if (!file.startsWith(options.root)) return undefined
-  if (fs.existsSync(file)) {
-    return file + postfix
-  } else if (tryIndex) {
-    const index = tryFsResolve(file + '/index', options, false)
-    if (index) return index + postfix
+  if (isFileReadable(file)) {
+    if (!fs.statSync(file).isDirectory()) {
+      return file + postfix
+    } else if (tryIndex) {
+      const index = tryFsResolve(file + '/index', options, false)
+      if (index) return index + postfix
+    }
   }
 
   const tryTsExtension = options.isFromTsImporter && isPossibleTsOutput(file)


### PR DESCRIPTION
Because it returns true for dirs too
Just copy node implementation